### PR TITLE
add react-native-nitro-audio-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A collection of published or works in progress Nitro Modules and any additional 
 - [react-native-turbo-scrypt](https://github.com/litecoin-foundation/react-native-turbo-scrypt)
 - [@corasan/image-compressor](https://github.com/corasan/image-compressor)
 - [react-native-nitro-event-kit](https://github.com/VladyslavMartynov10/react-native-nitro-event-kit)
+- [react-native-nitro-audio-manager](https://github.com/ChristopherGabba/react-native-nitro-audio-manager)
 
 ## Work In Progress
 


### PR DESCRIPTION
I recently released a new package called react-native-nitro-audio-manager that uses NitroModules to give access to native audio session / manager APIs